### PR TITLE
Commenting out protobuf includes and namespace usage

### DIFF
--- a/unit_testing/testloader.cpp
+++ b/unit_testing/testloader.cpp
@@ -1,9 +1,9 @@
-#include <google/protobuf/text_format.h>
+/*#include <google/protobuf/text_format.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/io/zero_copy_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>*/
 #include "testloader.h"
-using namespace google::protobuf;
+//using namespace google::protobuf;
 
 TestLoader::TestLoader() {}
 bool TestLoader::readFromString(const char *data, CodeBlock &tgt) {


### PR DESCRIPTION
Due to the dependencies for protobuf no longer being included needed to remove its includes, it might be worth completely removing these until protobuf is being used.
