### PR TITLE
Fix crash when loading hello-clang4-static

### DIFF
--- a/src/boomerang-loaders/elf/ElfBinaryLoader.cpp
+++ b/src/boomerang-loaders/elf/ElfBinaryLoader.cpp
@@ -1052,6 +1052,8 @@ void ElfBinaryLoader::applyRelocations()
                     default:
                         LOG_WARN("Unhandled x86 relocation type %1", static_cast<int>(relType));
                     }
+                    break;
+
                 default: LOG_WARN("Unhandled relocation!"); break;
                 }
             }


### PR DESCRIPTION
Crash was caused by .rel.plt referencing the NULL section in its sh_link field.
Do not apply relocations when sh_link does not reference a symbol table.