### PR TITLE
Fix crash when the first instruction of a callee is BSF or BSR.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ v0.5.0 (in development)
 -----------------------
 - Fixed: Crash when decoding instructions with multiple instruction prefixes in some cases.
 - Fixed: Crash when decompiling x86 binaries that contain specific variants of the JP or JNP instructions.
+- Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is BSF or BSR.
 - Feature: The x86 decoder now recognizes a larger subset of the x86 instruction set.
 - Improved: Better high level code output quality for x86 binaries due to more instructions being recognized.
 - Improved: Performance of decoding x86 instructions.

--- a/src/boomerang/frontend/DefaultFrontEnd.h
+++ b/src/boomerang/frontend/DefaultFrontEnd.h
@@ -138,6 +138,12 @@ private:
     /// Returns nullptr on failure.
     UserProc *createFunctionForEntryPoint(Address entryAddr, const QString &functionType);
 
+    /**
+     * Get the address of the destination of a library thunk.
+     * Returns Address::INVALID if the call is not a library thunk or an error occurred.
+     */
+    Address getAddrOfLibraryThunk(CallStatement *call, UserProc *proc);
+
 protected:
     std::unique_ptr<IDecoder> m_decoder;
     BinaryFile *m_binaryFile;


### PR DESCRIPTION
Crash was caused by not respecting the reDecode flag of a DecodeResult
when trying to decode a library thunk. This caused the state machine
to be out of step wrt the next BSF/BSR instruction.