### PR TITLE
Fix crash when decompiling functions where the first instruction is a…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ v0.5.0 (in development)
 - Fixed: Crash when decoding instructions with multiple instruction prefixes in some cases.
 - Fixed: Crash when decompiling x86 binaries that contain specific variants of the JP or JNP instructions.
 - Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is BSF or BSR.
+- Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is a string instruction.
 - Feature: The x86 decoder now recognizes a larger subset of the x86 instruction set.
 - Improved: Better high level code output quality for x86 binaries due to more instructions being recognized.
 - Improved: Performance of decoding x86 instructions.

--- a/src/boomerang/frontend/pentium/StringInstructionProcessor.cpp
+++ b/src/boomerang/frontend/pentium/StringInstructionProcessor.cpp
@@ -157,6 +157,7 @@ BasicBlock *StringInstructionProcessor::splitForBranch(BasicBlock *bb, RTL *stri
         succ->removePredecessor(bb);
     }
 
+    const bool entryBBNeedsUpdate = !haveA && bb == m_proc->getCFG()->getEntryBB();
     m_proc->getCFG()->removeBB(bb);
 
     BasicBlock *skipBB = m_proc->getCFG()->createBB(BBType::Twoway, std::move(skipBBRTLs));
@@ -185,6 +186,10 @@ BasicBlock *StringInstructionProcessor::splitForBranch(BasicBlock *bb, RTL *stri
     m_proc->getCFG()->addEdge(skipBB, rptBB);
     m_proc->getCFG()->addEdge(rptBB, bBB);
     m_proc->getCFG()->addEdge(rptBB, rptBB);
+
+    if (entryBBNeedsUpdate) {
+        m_proc->getCFG()->setEntryAndExitBB(skipBB);
+    }
 
     return haveB ? bBB : rptBB;
 }


### PR DESCRIPTION
… string instruction