### PR TITLE
Fix crashes when plugins cannot be loaded.

### DIFF
--- a/src/boomerang-plugins/frontend/ppc/PPCFrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/ppc/PPCFrontEnd.cpp
@@ -28,12 +28,10 @@ PPCFrontEnd::PPCFrontEnd(Project *project)
     : DefaultFrontEnd(project)
 {
     Plugin *plugin = project->getPluginManager()->getPluginByName("PPC decoder plugin");
-    if (!plugin) {
-        throw "Decoder plugin not found";
+    if (plugin) {
+        m_decoder = plugin->getIfc<IDecoder>();
+        m_decoder->initialize(project);
     }
-
-    m_decoder = plugin->getIfc<IDecoder>();
-    m_decoder->initialize(project);
 }
 
 

--- a/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
@@ -1275,12 +1275,10 @@ SPARCFrontEnd::SPARCFrontEnd(Project *project)
     : DefaultFrontEnd(project)
 {
     Plugin *plugin = project->getPluginManager()->getPluginByName("SPARC decoder plugin");
-    if (!plugin) {
-        throw "Decoder plugin not found";
+    if (plugin) {
+        m_decoder = plugin->getIfc<IDecoder>();
+        m_decoder->initialize(project);
     }
-
-    m_decoder = plugin->getIfc<IDecoder>();
-    m_decoder->initialize(project);
 
     nop_inst.numBytes = 0; // So won't disturb coverage
     nop_inst.type     = NOP;

--- a/src/boomerang-plugins/frontend/st20/ST20FrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/st20/ST20FrontEnd.cpp
@@ -24,12 +24,10 @@ ST20FrontEnd::ST20FrontEnd(Project *project)
     : DefaultFrontEnd(project)
 {
     Plugin *plugin = project->getPluginManager()->getPluginByName("ST20 decoder plugin");
-    if (!plugin) {
-        throw "Decoder plugin not found";
+    if (plugin) {
+        m_decoder = plugin->getIfc<IDecoder>();
+        m_decoder->initialize(project);
     }
-
-    m_decoder = plugin->getIfc<IDecoder>();
-    m_decoder->initialize(project);
 }
 
 

--- a/src/boomerang-plugins/frontend/x86/PentiumFrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/x86/PentiumFrontEnd.cpp
@@ -155,7 +155,7 @@ bool PentiumFrontEnd::initialize(Project *project)
 {
     Plugin *plugin = project->getPluginManager()->getPluginByName("Capstone x86 decoder plugin");
     if (!plugin) {
-        throw "Decoder plugin not found";
+        throw std::runtime_error("Decoder plugin not found.");
     }
 
     m_decoder = plugin->getIfc<IDecoder>();

--- a/src/boomerang/core/Project.cpp
+++ b/src/boomerang/core/Project.cpp
@@ -283,11 +283,13 @@ IFrontEnd *Project::createFrontEnd()
         }
 
         IFrontEnd *fe = plugin->getIfc<IFrontEnd>();
-        fe->initialize(this);
+        if (!fe->initialize(this)) {
+            throw std::runtime_error("FrontEnd initialization failed.");
+        }
         return fe;
     }
     catch (const std::runtime_error &err) {
-        LOG_ERROR("Cannot create frontend: %1", err.what());
+        LOG_ERROR("Cannot create FrontEnd: %1", err.what());
     }
 
     return nullptr;

--- a/src/boomerang/core/plugin/PluginHandle.cpp
+++ b/src/boomerang/core/plugin/PluginHandle.cpp
@@ -26,13 +26,13 @@ PluginHandle::PluginHandle(const QString &filePath)
     m_handle = LoadLibrary(qPrintable(filePath));
 
     if (m_handle == nullptr) {
-        throw "Failed to LoadLibrary!";
+        throw std::runtime_error("Failed to LoadLibrary!");
     }
 #else
     m_handle = dlopen(qPrintable(filePath), RTLD_NOW);
 
     if (m_handle == nullptr) {
-        throw dlerror();
+        throw std::runtime_error(dlerror());
     }
 #endif
 }

--- a/src/boomerang/frontend/DefaultFrontEnd.cpp
+++ b/src/boomerang/frontend/DefaultFrontEnd.cpp
@@ -52,6 +52,10 @@ bool DefaultFrontEnd::initialize(Project *project)
     m_program    = project->getProg();
     m_binaryFile = project->getLoadedBinaryFile();
 
+    if (!m_decoder) {
+        return false;
+    }
+
     return m_decoder->initialize(project);
 }
 

--- a/src/boomerang/frontend/DefaultFrontEnd.h
+++ b/src/boomerang/frontend/DefaultFrontEnd.h
@@ -147,9 +147,9 @@ private:
     Address getAddrOfLibraryThunk(CallStatement *call, UserProc *proc);
 
 protected:
-    IDecoder *m_decoder;
-    BinaryFile *m_binaryFile;
-    Prog *m_program;
+    IDecoder *m_decoder      = nullptr;
+    BinaryFile *m_binaryFile = nullptr;
+    Prog *m_program          = nullptr;
 
     TargetQueue m_targetQueue; ///< Holds the addresses that still need to be processed
 


### PR DESCRIPTION
Fixes 2 types of crashes:
 - Crash when dlopen()/LoadLibrary() fails. Caused by throwing unhandled exception.
 - Crash when FrontEnd plugins cannot find their decoder plugins.