### PR TITLE
Fix decompilation of cmovs instruction

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ v0.5.0 (in development)
 - Improved: Performance of decoding x86 instructions.
 - Improved: General processing of overlapped registers (not just hard-coded ones).
 - Improved: Better high level code output quality for x86 binaries due to more instructions being recognized.
+- Improved: Type Analysis of code containing ternary ?: operator.
 - Improved: Unit test coverage.
 - Improved: Regression test coverage.
 - Changed: Replaced old pentium (x86) decoder by x86 decoder using libcapstone for decoding instructions.

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ v0.5.0 (in development)
 - Fixed: Signature promotion ignored '-nP' switch.
 - Fixed: Wrong decompilation of "Pass by pointer/reference" values (e.g. `foo(&local0)` was emitted as `foo(esp-32)`).
 - Fixed: Wrong decompilation of parameter types in function signatures in some cases.
+- Fixed: Wrong decompilation of x86 binaries containing a `cmovs` instruction.
 - Fixed: Unnecessary union types in high-level code due to non-symmetric type meet operator.
 - Fixed: Memory leaks in parsers.
 - Feature: The x86 decoder now recognizes a larger subset of the x86 instruction set.

--- a/data/ssl/x86.ssl
+++ b/data/ssl/x86.ssl
@@ -1242,89 +1242,89 @@ CMC
 
 
 # CMOVcc
-CMOVA.reg32.reg32    dest, src      *32* ~%CF & ~%ZF         => dest := src;
-CMOVA.reg32.rm32     dest, src      *32* ~%CF & ~%ZF         => dest := src;
+CMOVA.reg32.reg32    dest, src      *32* dest := [(~%CF & ~%ZF)         ? src : dest];
+CMOVA.reg32.rm32     dest, src      *32* dest := [(~%CF & ~%ZF)         ? src : dest];
 
-CMOVAE.reg32.reg32   dest, src      *32* %CF = 0             => dest := src;
-CMOVAE.reg32.rm32    dest, src      *32* %CF = 0             => dest := src;
+CMOVAE.reg32.reg32   dest, src      *32* dest := [(%CF = 0)             ? src : dest];
+CMOVAE.reg32.rm32    dest, src      *32* dest := [(%CF = 0)             ? src : dest];
 
-CMOVB.reg32.reg32    dest, src      *32* %CF = 1             => dest := src;
-CMOVB.reg32.rm32     dest, src      *32* %CF = 1             => dest := src;
+CMOVB.reg32.reg32    dest, src      *32* dest := [(%CF = 1)             ? src : dest];
+CMOVB.reg32.rm32     dest, src      *32* dest := [(%CF = 1)             ? src : dest];
 
-CMOVBE.reg32.reg32   dest, src      *32* %CF | %ZF           => dest := src;
-CMOVBE.reg32.rm32    dest, src      *32* %CF | %ZF           => dest := src;
+CMOVBE.reg32.reg32   dest, src      *32* dest := [(%CF | %ZF)           ? src : dest];
+CMOVBE.reg32.rm32    dest, src      *32* dest := [(%CF | %ZF)           ? src : dest];
 
-CMOVC.reg32.reg32    dest, src      *32* %CF = 1             => dest := src;
-CMOVC.reg32.rm32     dest, src      *32* %CF = 1             => dest := src;
+CMOVC.reg32.reg32    dest, src      *32* dest := [(%CF = 1)             ? src : dest];
+CMOVC.reg32.rm32     dest, src      *32* dest := [(%CF = 1)             ? src : dest];
 
-CMOVE.reg32.reg32    dest, src      *32* %ZF = 1             => dest := src;
-CMOVE.reg32.rm32     dest, src      *32* %ZF = 1             => dest := src;
+CMOVE.reg32.reg32    dest, src      *32* dest := [(%ZF = 1)             ? src : dest];
+CMOVE.reg32.rm32     dest, src      *32* dest := [(%ZF = 1)             ? src : dest];
 
-CMOVG.reg32.reg32    dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
-CMOVG.reg32.rm32     dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
+CMOVG.reg32.reg32    dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
+CMOVG.reg32.rm32     dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
 
-CMOVGE.reg32.reg32   dest, src      *32* ~(%SF ^ %OF)        => dest := src;
-CMOVGE.reg32.rm32    dest, src      *32* ~(%SF ^ %OF)        => dest := src;
+CMOVGE.reg32.reg32   dest, src      *32* dest := [(~(%SF ^ %OF))        ? src : dest];
+CMOVGE.reg32.rm32    dest, src      *32* dest := [(~(%SF ^ %OF))        ? src : dest];
 
-CMOVL.reg32.reg32    dest, src      *32* %SF ^ %OF           => dest := src;
-CMOVL.reg32.rm32     dest, src      *32* %SF ^ %OF           => dest := src;
+CMOVL.reg32.reg32    dest, src      *32* dest := [(%SF ^ %OF)           ? src : dest];
+CMOVL.reg32.rm32     dest, src      *32* dest := [(%SF ^ %OF)           ? src : dest];
 
-CMOVLE.reg32.reg32   dest, src      *32* %ZF | (%SF ^ %OF)   => dest := src;
-CMOVLE.reg32.rm32    dest, src      *32* %ZF | (%SF ^ %OF)   => dest := src;
+CMOVLE.reg32.reg32   dest, src      *32* dest := [(%ZF | (%SF ^ %OF))   ? src : dest];
+CMOVLE.reg32.rm32    dest, src      *32* dest := [(%ZF | (%SF ^ %OF))   ? src : dest];
 
-CMOVNA.reg32.reg32   dest, src      *32* %CF | %ZF           => dest := src;
-CMOVNA.reg32.rm32    dest, src      *32* %CF | %ZF           => dest := src;
+CMOVNA.reg32.reg32   dest, src      *32* dest := [(%CF | %ZF)           ? src : dest];
+CMOVNA.reg32.rm32    dest, src      *32* dest := [(%CF | %ZF)           ? src : dest];
 
-CMOVNAE.reg32.reg32  dest, src      *32* %CF = 1             => dest := src;
-CMOVNAE.reg32.rm32   dest, src      *32* %CF = 1             => dest := src;
+CMOVNAE.reg32.reg32  dest, src      *32* dest := [(%CF = 1)             ? src : dest];
+CMOVNAE.reg32.rm32   dest, src      *32* dest := [(%CF = 1)             ? src : dest];
 
-CMOVNB.reg32.reg32   dest, src      *32* %CF = 0             => dest := src;
-CMOVNB.reg32.rm32    dest, src      *32* %CF = 0             => dest := src;
+CMOVNB.reg32.reg32   dest, src      *32* dest := [(%CF = 0)             ? src : dest];
+CMOVNB.reg32.rm32    dest, src      *32* dest := [(%CF = 0)             ? src : dest];
 
-CMOVNBE.reg32.reg32  dest, src      *32* (~%CF & ~%ZF)       => dest := src;
-CMOVNBE.reg32.rm32   dest, src      *32* (~%CF & ~%ZF)       => dest := src;
+CMOVNBE.reg32.reg32  dest, src      *32* dest := [(~%CF & ~%ZF)         ? src : dest];
+CMOVNBE.reg32.rm32   dest, src      *32* dest := [(~%CF & ~%ZF)         ? src : dest];
 
-CMOVNC.reg32.reg32   dest, src      *32* %CF = 0             => dest := src;
-CMOVNC.reg32.rm32    dest, src      *32* %CF = 0             => dest := src;
+CMOVNC.reg32.reg32   dest, src      *32* dest := [(%CF = 0)             ? src : dest];
+CMOVNC.reg32.rm32    dest, src      *32* dest := [(%CF = 0)             ? src : dest];
 
-CMOVNE.reg32.reg32   dest, src      *32* %ZF = 0             => dest := src;
-CMOVNE.reg32.rm32    dest, src      *32* %ZF = 0             => dest := src;
+CMOVNE.reg32.reg32   dest, src      *32* dest := [(%ZF = 0)             ? src : dest];
+CMOVNE.reg32.rm32    dest, src      *32* dest := [(%ZF = 0)             ? src : dest];
 
-CMOVNG.reg32.reg32   dest, src      *32* %ZF | (%SF ^ %OF)   => dest := src;
-CMOVNG.reg32.rm32    dest, src      *32* %ZF | (%SF ^ %OF)   => dest := src;
+CMOVNG.reg32.reg32   dest, src      *32* dest := [(%ZF | (%SF ^ %OF))   ? src : dest];
+CMOVNG.reg32.rm32    dest, src      *32* dest := [(%ZF | (%SF ^ %OF))   ? src : dest];
 
-CMOVNGE.reg32.reg32  dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
-CMOVNGE.reg32.rm32   dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
+CMOVNGE.reg32.reg32  dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
+CMOVNGE.reg32.rm32   dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
 
-CMOVNL.reg32.reg32   dest, src      *32* ~(%SF ^ %OF)        => dest := src;
-CMOVNL.reg32.rm32    dest, src      *32* ~(%SF ^ %OF)        => dest := src;
+CMOVNL.reg32.reg32   dest, src      *32* dest := [(~(%SF ^ %OF))        ? src : dest];
+CMOVNL.reg32.rm32    dest, src      *32* dest := [(~(%SF ^ %OF))        ? src : dest];
 
-CMOVNLE.reg32.reg32  dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
-CMOVNLE.reg32.rm32   dest, src      *32* ~%ZF & ~(%SF ^ %OF) => dest := src;
+CMOVNLE.reg32.reg32  dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
+CMOVNLE.reg32.rm32   dest, src      *32* dest := [(~%ZF & ~(%SF ^ %OF)) ? src : dest];
 
-CMOVNO.reg32.reg32   dest, src      *32* ~%OF                => dest := src;
-CMOVNO.reg32.rm32    dest, src      *32* ~%OF                => dest := src;
+CMOVNO.reg32.reg32   dest, src      *32* dest := [(~%OF)                ? src : dest];
+CMOVNO.reg32.rm32    dest, src      *32* dest := [(~%OF)                ? src : dest];
 
-CMOVNP.reg32.reg32   dest, src      *32* ~%PF                => dest := src;
-CMOVNP.reg32.rm32    dest, src      *32* ~%PF                => dest := src;
+CMOVNP.reg32.reg32   dest, src      *32* dest := [(~%PF)                ? src : dest];
+CMOVNP.reg32.rm32    dest, src      *32* dest := [(~%PF)                ? src : dest];
 
-CMOVNS.reg32.reg32   dest, src      *32* ~%SF                => dest := src;
-CMOVNS.reg32.rm32    dest, src      *32* ~%SF                => dest := src;
+CMOVNS.reg32.reg32   dest, src      *32* dest := [(~%SF)                ? src : dest];
+CMOVNS.reg32.rm32    dest, src      *32* dest := [(~%SF)                ? src : dest];
 
-CMOVNE.reg32.reg32   dest, src      *32* ~%ZF                => dest := src;
-CMOVNE.reg32.rm32    dest, src      *32* ~%ZF                => dest := src;
+CMOVNE.reg32.reg32   dest, src      *32* dest := [(~%ZF)                ? src : dest];
+CMOVNE.reg32.rm32    dest, src      *32* dest := [(~%ZF)                ? src : dest];
 
-CMOVO.reg32.reg32    dest, src      *32* %OF                 => dest := src;
-CMOVO.reg32.rm32     dest, src      *32* %OF                 => dest := src;
+CMOVO.reg32.reg32    dest, src      *32* dest := [(%OF)                 ? src : dest];
+CMOVO.reg32.rm32     dest, src      *32* dest := [(%OF)                 ? src : dest];
 
-CMOVP.reg32.reg32    dest, src      *32* %PF                 => dest := src;
-CMOVP.reg32.rm32     dest, src      *32* %PF                 => dest := src;
+CMOVP.reg32.reg32    dest, src      *32* dest := [(%PF)                 ? src : dest];
+CMOVP.reg32.rm32     dest, src      *32* dest := [(%PF)                 ? src : dest];
 
-CMOVS.reg32.reg32    dest, src      *32* %SF                 => dest := src;
-CMOVS.reg32.rm32     dest, src      *32* %SF                 => dest := src;
+CMOVS.reg32.reg32    dest, src      *32* dest := [(%SF)                 ? src : dest];
+CMOVS.reg32.rm32     dest, src      *32* dest := [(%SF)                 ? src : dest];
 
-CMOVZ.reg32.reg32    dest, src      *32* %ZF                 => dest := src;
-CMOVZ.reg32.rm32     dest, src      *32* %ZF                 => dest := src;
+CMOVZ.reg32.reg32    dest, src      *32* dest := [(%ZF)                 ? src : dest];
+CMOVZ.reg32.rm32     dest, src      *32* dest := [(%ZF)                 ? src : dest];
 
 
 # CMP

--- a/src/boomerang/db/proc/UserProc.cpp
+++ b/src/boomerang/db/proc/UserProc.cpp
@@ -476,6 +476,8 @@ bool UserProc::filterReturns(SharedExp e)
         // Would like to handle at least %ZF, %CF one day. For now, filter them out
     case opZF:
     case opCF:
+    case opNF:
+    case opOF:
     case opFlags: return true;
 
     case opMemOf:

--- a/src/boomerang/ssl/exp/Ternary.cpp
+++ b/src/boomerang/ssl/exp/Ternary.cpp
@@ -211,7 +211,7 @@ SharedType Ternary::ascendType()
 }
 
 
-bool Ternary::descendType(SharedType /*newType*/)
+bool Ternary::descendType(SharedType newType)
 {
     switch (m_oper) {
     case opFsize: return subExp3->descendType(FloatType::get(access<Const, 1>()->getInt()));
@@ -220,6 +220,12 @@ bool Ternary::descendType(SharedType /*newType*/)
         const int fromSize = access<Const, 1>()->getInt();
         const Sign sign    = m_oper == opZfill ? Sign::Unsigned : Sign::Signed;
         return subExp3->descendType(Type::newIntegerLikeType(fromSize, sign));
+    }
+    case opTern: {
+        bool thisChanged = false;
+        thisChanged |= subExp2->descendType(newType);
+        thisChanged |= subExp3->descendType(newType);
+        return thisChanged;
     }
 
     default: return false;

--- a/src/boomerang/ssl/statements/Assignment.cpp
+++ b/src/boomerang/ssl/statements/Assignment.cpp
@@ -103,6 +103,8 @@ void Assignment::getDefinitions(LocationSet &defs, bool) const
     if (m_lhs->isFlags()) {
         defs.insert(Terminal::get(opCF));
         defs.insert(Terminal::get(opZF));
+        defs.insert(Terminal::get(opOF));
+        defs.insert(Terminal::get(opNF));
     }
 }
 

--- a/src/boomerang/ssl/statements/Statement.cpp
+++ b/src/boomerang/ssl/statements/Statement.cpp
@@ -480,8 +480,7 @@ bool Statement::replaceRef(SharedExp e, Assignment *def, bool &convert)
 
         const QString str = rhs->access<Const, 1>()->getStr();
         if (str.startsWith("LOGICALFLAGS")) {
-            SharedExp relExp = Binary::get(opLess, rhs->getSubExp2()->getSubExp1(),
-                                           Const::get(0));
+            SharedExp relExp = Binary::get(opLess, rhs->getSubExp2()->getSubExp1(), Const::get(0));
             searchAndReplace(*RefExp::get(Terminal::get(opNF), def), relExp, true);
             return true;
         }

--- a/src/boomerang/ssl/statements/Statement.cpp
+++ b/src/boomerang/ssl/statements/Statement.cpp
@@ -473,6 +473,20 @@ bool Statement::replaceRef(SharedExp e, Assignment *def, bool &convert)
         }
     }
 
+    if (base->getOper() == opNF && lhs->isFlags()) {
+        if (!rhs->isFlagCall()) {
+            return false;
+        }
+
+        const QString str = rhs->access<Const, 1>()->getStr();
+        if (str.startsWith("LOGICALFLAGS")) {
+            SharedExp relExp = Binary::get(opLess, rhs->getSubExp2()->getSubExp1(),
+                                           Const::get(0));
+            searchAndReplace(*RefExp::get(Terminal::get(opNF), def), relExp, true);
+            return true;
+        }
+    }
+
     // do the replacement
     // bool convert = doReplaceRef(re, rhs);
     bool ret = searchAndReplace(*e, rhs, true); // Last parameter true to change collectors

--- a/tests/regression-tests/expected-outputs/pentium/asgngoto/asgngoto/asgngoto.c
+++ b/tests/regression-tests/expected-outputs/pentium/asgngoto/asgngoto/asgngoto.c
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
     f_setsig();
     f_init();
     eax = atexit(0x8048584); /* Warning: also results in ecx, edx */
-    MAIN__(eax, ecx, edx, esp - 4, SUBFLAGS32((esp - 12), 16, esp - 28), esp == 28, (unsigned int)(esp - 12) < 16, argc, argv, ebp, argv, 0x8048584, pc);
+    MAIN__(eax, ecx, edx, esp - 4, SUBFLAGS32((esp - 12), 16, esp - 28), esp == 28, (unsigned int)(esp - 12) < 16, SUBFLAGS32(esp - 12, 16, esp - 28), SUBFLAGS32(esp - 12, 16, esp - 28), argc, argv, ebp, argv, 0x8048584, pc);
 }
 
 /** address: 0x08048904 */

--- a/tests/regression-tests/expected-outputs/pentium/funcptr/funcptr/funcptr.c
+++ b/tests/regression-tests/expected-outputs/pentium/funcptr/funcptr/funcptr.c
@@ -14,10 +14,10 @@ int main(int argc, char *argv[])
     char * *local4; 		// m[esp + 8]
     int local5; 		// m[esp - 12]
 
-    (*0x8048328)(0x8048328, esp - 4, SUBFLAGS32((esp - 12), 0, esp - 12), esp == 12, esp < 12, ebp, 0x8048328, pc, argc, argv);
+    (*0x8048328)(0x8048328, esp - 4, SUBFLAGS32((esp - 12), 0, esp - 12), esp == 12, esp < 12, SUBFLAGS32(esp - 12, 0, esp - 12), SUBFLAGS32(esp - 12, 0, esp - 12), ebp, 0x8048328, pc, argc, argv);
     *(__size32*)(ebp - 4) = 0x8048340;
     eax = *(ebp - 4);
-    (*eax)(eax, ebp, <all>, flags, ZF, CF, local0, local1, local2, local3, local4);
+    (*eax)(eax, ebp, <all>, flags, ZF, CF, NF, OF, local0, local1, local2, local3, local4);
     return 0;
 }
 


### PR DESCRIPTION
Fixes #122.
Also fixes an issue where types would not be propagated through the ternary ?: operator.