### PR TITLE
Fix printing of TypedExp

### DIFF
--- a/src/boomerang/util/ExpPrinter.cpp
+++ b/src/boomerang/util/ExpPrinter.cpp
@@ -233,7 +233,9 @@ void ExpPrinter::printPlain(OStream &os, const SharedConstExp &exp) const
 
     case opTypedExp: {
         SharedConstType ty = exp->access<const TypedExp>()->getType();
-        os << "<" << ty->getSize() << ">";
+        os << "(" << *ty << ")(";
+        print(os, exp->getSubExp1());
+        os << ")";
         return;
     }
 


### PR DESCRIPTION
TypedExps did not print their subexpressions.