### PR TITLE
Clean up trailing comments

### DIFF
--- a/src/boomerang-gui/MainWindow.cpp
+++ b/src/boomerang-gui/MainWindow.cpp
@@ -107,8 +107,9 @@ MainWindow::MainWindow(QWidget *_parent)
 
     if (ui->cbInputFile->count() > 0) {
         int currentIdx = ui->cbInputFile->findText(settings.value("inputfile").toString());
-        currentIdx     = std::max(currentIdx,
-                              0); // if selected input file could not be found, use last one
+
+        // if selected input file could not be found, use last one
+        currentIdx = std::max(currentIdx, 0);
         ui->cbInputFile->setCurrentIndex(currentIdx);
     }
 

--- a/src/boomerang-plugins/codegen/c/CCodeGenerator.cpp
+++ b/src/boomerang-plugins/codegen/c/CCodeGenerator.cpp
@@ -1859,8 +1859,9 @@ void CCodeGenerator::appendTypeIdent(OStream &str, SharedConstType typ, QString 
 
         str << "]";
     }
-    else if (typ->isVoid()) { // Can happen in e.g. twoproc, where really need global parameter and
-                              // return analysis
+    // Can happen in e.g. twoproc, where really need global parameter and
+    // return analysis
+    else if (typ->isVoid()) {
         // TMN: Stop crashes by this workaround
         if (ident.isEmpty()) {
             ident = "unknownVoidType";
@@ -2242,11 +2243,11 @@ void CCodeGenerator::generateCode_Branch(const BasicBlock *bb,
             Const caseVal(0);
 
             if (psi->switchType == SwitchType::F) { // "Fortran" style?
-                caseVal.setInt(reinterpret_cast<int *>(
-                    psi->tableAddr.value())[i]); // Yes, use the table value itself
+                // Yes, use the table value itself
+                caseVal.setInt(reinterpret_cast<int *>(psi->tableAddr.value())[i]);
             }
-            // Note that uTable has the address of an int array
             else {
+                // Note that uTable has the address of an int array
                 caseVal.setInt(static_cast<int>(psi->lowerBound + i));
             }
 

--- a/src/boomerang-plugins/codegen/c/ControlFlowAnalyzer.h
+++ b/src/boomerang-plugins/codegen/c/ControlFlowAnalyzer.h
@@ -104,8 +104,7 @@ struct BBStructInfo
 
     /* high level structuring */
     SBBType m_loopCondType = SBBType::None; ///< type of conditional to treat this loop header as
-                                            ///< (if any)
-    SBBType m_structType = SBBType::None;   ///< structured type of this node
+    SBBType m_structType   = SBBType::None; ///< structured type of this node
 
     /// the structuring class (Loop, Cond, etc)
     StructType m_structuringType = StructType::Seq;

--- a/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
@@ -219,12 +219,10 @@ bool SPARCFrontEnd::case_CALL(Address &address, DecodeResult &inst, DecodeResult
             // struct, 12 bytes ahead. But the problem is: how do you know this function returns a
             // struct at decode time? If forceOutEdge is set, set offset to 0 and no out-edge will
             // be added yet
-            int offset = !inst.forceOutEdge.isZero() ? 0 :
-                                                     // (call_stmt->returnsStruct() ? 12 : 8);
-                                                     // MVE: FIXME!
-                             8;
+            // MVE: FIXME!
+            int offset = !inst.forceOutEdge.isZero() ? 0 : /*call_stmt->returnsStruct()?12:8*/ 8;
+            bool ret   = true;
 
-            bool ret = true;
             // Check for _exit; probably should check for other "never return" functions
             QString name = m_program->getSymbolNameByAddr(dest);
 

--- a/src/boomerang-plugins/type/dfa/DFATypeRecovery.cpp
+++ b/src/boomerang-plugins/type/dfa/DFATypeRecovery.cpp
@@ -414,9 +414,9 @@ void DFATypeRecovery::dfaTypeAnalysis(UserProc *proc)
                             Binary::get(opArrayIndex,
                                         Location::global(_prog->getGlobalNameByAddr(K), proc),
                                         idx));
-                        // Beware of changing expressions in implicit assignments... map can become
-                        // invalid
-                        bool isImplicit = s->isImplicit();
+                        // Beware of changing expressions in implicit assignments...
+                        // map can become invalid
+                        const bool isImplicit = s->isImplicit();
 
                         if (isImplicit) {
                             cfg->removeImplicitAssign(static_cast<ImplicitAssign *>(s)->getLeft());
@@ -446,8 +446,7 @@ void DFATypeRecovery::dfaTypeAnalysis(UserProc *proc)
                     // Reinterpret as a float (and convert to double)
                     // con->setFlt(reinterpret_cast<float>(con->getInt()));
                     int tmp = con->getInt();
-                    con->setFlt(*reinterpret_cast<float *>(
-                        &tmp)); // Reinterpret to float, then cast to double
+                    con->setFlt(*reinterpret_cast<float *>(&tmp));
                     con->setOper(opFltConst);
                     con->setType(FloatType::get(64)); // TODO: why double ? float might do
                 }

--- a/src/boomerang/db/DataFlow.cpp
+++ b/src/boomerang/db/DataFlow.cpp
@@ -307,9 +307,10 @@ bool DataFlow::placePhiFunctions()
             LocationSet locationSet;
             stmt->getDefinitions(locationSet, assumeABICompliance);
 
-            if (stmt->isCall() && static_cast<const CallStatement *>(stmt)
-                                      ->isChildless()) { // If this is a childless call
-                m_defallsites.insert(n);                 // then this block defines every variable
+            // If this is a childless call
+            if (stmt->isCall() && static_cast<const CallStatement *>(stmt)->isChildless()) {
+                // then this block defines every variable
+                m_defallsites.insert(n);
             }
 
             for (const SharedExp &exp : locationSet) {

--- a/src/boomerang/db/proc/UserProc.cpp
+++ b/src/boomerang/db/proc/UserProc.cpp
@@ -1331,8 +1331,8 @@ bool UserProc::prover(SharedExp query, std::set<PhiAssign *> &lastPhis,
                     } // End call involved in this recursion group
 
                     // Seems reasonable that recursive procs need protection from call loops too
-                    auto right = call->getProven(
-                        r->getSubExp1()); // getProven returns the right side of what is
+                    // getProven returns the right side of what is
+                    auto right = call->getProven(r->getSubExp1());
 
                     if (right) { //    proven about r (the LHS of query)
                         right = right->clone();

--- a/src/boomerang/db/proc/UserProc.h
+++ b/src/boomerang/db/proc/UserProc.h
@@ -380,13 +380,12 @@ private:
     bool isNoReturnInternal(std::set<const Function *> &visited) const;
 
 private:
-    /**
-     * The status of this user procedure.
-     * Status: undecoded .. final decompiled
-     */
+    /// The status of this user procedure.
+    /// Status: undecoded .. final decompiled
     ProcStatus m_status = ProcStatus::Undecoded;
-    int m_nextLocal     = 0; ///< Number of the next local. Can't use locals.size() because some get
-                             ///< deleted
+
+    /// Number of the next local. Can't use locals.size() because some get deleted
+    int m_nextLocal = 0;
 
     std::unique_ptr<ProcCFG> m_cfg; ///< The control flow graph.
 

--- a/src/boomerang/decomp/IndirectJumpAnalyzer.cpp
+++ b/src/boomerang/decomp/IndirectJumpAnalyzer.cpp
@@ -559,9 +559,8 @@ bool IndirectJumpAnalyzer::analyzeCompJump(BasicBlock *bb, UserProc *proc)
                     SwitchInfo *swi = new SwitchInfo;
                     swi->switchType = SwitchType::F; // The "Fortran" form
                     swi->switchExp  = jumpDest;
-                    swi->tableAddr  = Address(
-                        HostAddress(destArray).value()); // WARN: HACK HACK HACK Abuse the
-                    // tableAddr member as a pointer
+                    // WARN: HACK HACK HACK Abuse the tableAddr member as a pointer
+                    swi->tableAddr       = Address(HostAddress(destArray).value());
                     swi->lowerBound      = 1; // Not used, except to compute
                     swi->upperBound      = static_cast<int>(num_dests); // the number of options
                     swi->numTableEntries = static_cast<int>(num_dests);

--- a/src/boomerang/decomp/ProcDecompiler.cpp
+++ b/src/boomerang/decomp/ProcDecompiler.cpp
@@ -578,10 +578,10 @@ void ProcDecompiler::middleDecompile(UserProc *proc)
 
         // Now that locals are identified, redo the dataflow
         PassManager::get()->executePass(PassID::PhiPlacement, proc);
+        PassManager::get()->executePass(PassID::BlockVarRename, proc);
 
-        PassManager::get()->executePass(PassID::BlockVarRename, proc); // Rename the locals
-        PassManager::get()->executePass(PassID::StatementPropagation,
-                                        proc); // Surely need propagation too
+        // Surely need propagation too
+        PassManager::get()->executePass(PassID::StatementPropagation, proc);
 
         if (project->getSettings()->verboseOutput) {
             proc->debugPrintAll("after propagating locals");

--- a/src/boomerang/decomp/UnusedReturnRemover.cpp
+++ b/src/boomerang/decomp/UnusedReturnRemover.cpp
@@ -249,8 +249,7 @@ void UnusedReturnRemover::updateForUseChange(UserProc *proc)
     }
 
     // Have to redo dataflow to get the liveness at the calls correct
-    PassManager::get()->executePass(PassID::CallLivenessRemoval,
-                                    proc); // Want to recompute the call livenesses
+    PassManager::get()->executePass(PassID::CallLivenessRemoval, proc);
     PassManager::get()->executePass(PassID::BlockVarRename, proc);
 
     // Perform type analysis. If we are relying (as we are at present) on TA to perform ellipsis

--- a/src/boomerang/passes/dataflow/BlockVarRenamePass.cpp
+++ b/src/boomerang/passes/dataflow/BlockVarRenamePass.cpp
@@ -133,8 +133,8 @@ bool BlockVarRenamePass::renameBlockVars(
 
 
                 if (def && def->isCall()) {
-                    // Calls have UseCollectors for locations that are used before definition at the
-                    // call
+                    // Calls have UseCollectors for locations that are used before definition
+                    // at the call
                     static_cast<CallStatement *>(def)->useBeforeDefine(location->clone());
                 }
 

--- a/src/boomerang/passes/late/UnusedParamRemovalPass.cpp
+++ b/src/boomerang/passes/late/UnusedParamRemovalPass.cpp
@@ -149,9 +149,9 @@ bool UnusedParamRemovalPass::checkForGainfulUse(UserProc *proc, SharedExp bparam
             }
         }
         else if (s->isReturn()) {
-            if (proc->getRecursionGroup() &&
-                !proc->getRecursionGroup()->empty()) { // If this function is involved in recursion
-                continue;                              //  then ignore this return statement
+            if (proc->getRecursionGroup() && !proc->getRecursionGroup()->empty()) {
+                // If this functions is involved in recursion, then ignore this return statement
+                continue;
             }
         }
         else if (s->isPhi() && (proc->getRetStmt() != nullptr) && proc->getRecursionGroup() &&

--- a/src/boomerang/ssl/statements/CallStatement.cpp
+++ b/src/boomerang/ssl/statements/CallStatement.cpp
@@ -1153,9 +1153,8 @@ bool CallStatement::ellipsisProcessing(Prog *prog)
         case 'E': // Various floating point formats
             // Note that for scanf, %f means float, and %lf means double, whereas for printf, both
             // of these mean double
-            addSigParam(FloatType::get(veryLong ? 128 : (isScanf ? 32 : 64)),
-                        isScanf); // Note: may not be 64 bits
-            // for some archs
+            // Note: may not be 64 bits for some archs
+            addSigParam(FloatType::get(veryLong ? 128 : (isScanf ? 32 : 64)), isScanf);
             break;
 
         case 's': // String

--- a/src/boomerang/ssl/statements/PhiAssign.cpp
+++ b/src/boomerang/ssl/statements/PhiAssign.cpp
@@ -47,9 +47,8 @@ Statement *PhiAssign::clone() const
         const RefExp &pi = val.second;
         assert(pi.getSubExp1());
 
-        RefExp clone(pi.getSubExp1()->clone(), // Do clone the expression pointer
-                     pi.getDef());             // Don't clone the Statement pointer (never moves)
-
+        // Clone the expression pointer, but not the statement pointer (never moves)
+        RefExp clone(pi.getSubExp1()->clone(), pi.getDef());
         pa->m_defs.insert({ bb, RefExp(pi.getSubExp1()->clone(), pi.getDef()) });
     }
 


### PR DESCRIPTION
Cleans up leftovers from initial clang-format run.