### PR TITLE
Fix build error when using CMake 3.11 or below.

### DIFF
--- a/src/boomerang-plugins/symbol/c/parser/CMakeLists.txt
+++ b/src/boomerang-plugins/symbol/c/parser/CMakeLists.txt
@@ -38,7 +38,7 @@ endif (NOT BISON_AnsiCParser_DEFINED)
 
 ADD_FLEX_BISON_DEPENDENCY(AnsiCScanner AnsiCParser)
 
-add_library(boomerang-ansic-parser OBJECT
+add_library(boomerang-ansic-parser STATIC
     ${BISON_AnsiCParser_OUTPUTS}
     ${FLEX_AnsiCScanner_OUTPUTS}
     AnsiCParserDriver.cpp

--- a/src/boomerang/ssl/parser/CMakeLists.txt
+++ b/src/boomerang/ssl/parser/CMakeLists.txt
@@ -38,7 +38,7 @@ endif (NOT BISON_SSL2Parser_DEFINED)
 
 ADD_FLEX_BISON_DEPENDENCY(SSL2Scanner SSL2Parser)
 
-add_library(boomerang-ssl2-parser OBJECT
+add_library(boomerang-ssl2-parser STATIC
     ${BISON_SSL2Parser_OUTPUTS}
     ${FLEX_SSL2Scanner_OUTPUTS}
     SSL2ParserDriver.cpp


### PR DESCRIPTION
Support for linking object libraries is only available for CMake 3.12 and up.
Fixes #205.