### PR TITLE
Fix Clang 8 compilation

### DIFF
--- a/src/boomerang-plugins/codegen/c/CodeWriter.h
+++ b/src/boomerang-plugins/codegen/c/CodeWriter.h
@@ -27,12 +27,12 @@ class CodeWriter
     {
         WriteDest(const QString &outFileName);
         WriteDest(const WriteDest &) = delete;
-        WriteDest(WriteDest &&)      = default;
+        WriteDest(WriteDest &&)      = delete;
 
         ~WriteDest();
 
         WriteDest &operator=(const WriteDest &) = delete;
-        WriteDest &operator=(WriteDest &&) = default;
+        WriteDest &operator=(WriteDest &&) = delete;
 
         QFile m_outFile;
         OStream m_os;

--- a/src/boomerang/ssl/statements/CallStatement.h
+++ b/src/boomerang/ssl/statements/CallStatement.h
@@ -31,12 +31,12 @@ class BOOMERANG_API CallStatement : public GotoStatement
 {
 public:
     CallStatement();
-    CallStatement(const CallStatement &other) = default;
+    CallStatement(const CallStatement &other) = delete;
     CallStatement(CallStatement &&other)      = default;
 
     virtual ~CallStatement() override;
 
-    CallStatement &operator=(const CallStatement &other) = default;
+    CallStatement &operator=(const CallStatement &other) = delete;
     CallStatement &operator=(CallStatement &&other) = default;
 
 public:

--- a/src/boomerang/ssl/statements/PhiAssign.h
+++ b/src/boomerang/ssl/statements/PhiAssign.h
@@ -55,13 +55,13 @@ public:
         m_kind = StmtType::PhiAssign;
     }
 
-    PhiAssign(const PhiAssign &other) = default;
-    PhiAssign(PhiAssign &&other)      = default;
+    PhiAssign(const PhiAssign &other) = delete;
+    PhiAssign(PhiAssign &&other)      = delete;
 
     virtual ~PhiAssign() override { m_defs.~PhiDefs(); }
 
-    PhiAssign &operator=(const PhiAssign &other) = default;
-    PhiAssign &operator=(PhiAssign &&other) = default;
+    PhiAssign &operator=(const PhiAssign &other) = delete;
+    PhiAssign &operator=(PhiAssign &&other) = delete;
 
 public:
     iterator begin() { return m_defs.begin(); }

--- a/src/boomerang/ssl/statements/ReturnStatement.h
+++ b/src/boomerang/ssl/statements/ReturnStatement.h
@@ -26,12 +26,12 @@ public:
 
 public:
     ReturnStatement();
-    ReturnStatement(const ReturnStatement &other) = default;
+    ReturnStatement(const ReturnStatement &other) = delete;
     ReturnStatement(ReturnStatement &&other)      = default;
 
     virtual ~ReturnStatement() override;
 
-    ReturnStatement &operator=(const ReturnStatement &other) = default;
+    ReturnStatement &operator=(const ReturnStatement &other) = delete;
     ReturnStatement &operator=(ReturnStatement &&other) = default;
 
 public:

--- a/src/boomerang/util/log/SeparateLogger.h
+++ b/src/boomerang/util/log/SeparateLogger.h
@@ -22,12 +22,12 @@ public:
     /// \param fullFilePath Full absolute path to the log file
     SeparateLogger(const QString &fullFilePath);
     SeparateLogger(const SeparateLogger &other) = delete;
-    SeparateLogger(SeparateLogger &&other)      = default;
+    SeparateLogger(SeparateLogger &&other)      = delete;
 
     virtual ~SeparateLogger() override = default;
 
     SeparateLogger &operator=(const SeparateLogger &other) = delete;
-    SeparateLogger &operator=(SeparateLogger &&other) = default;
+    SeparateLogger &operator=(SeparateLogger &&other) = delete;
 
 public:
     static SeparateLogger &getOrCreateLog(const QString &name);

--- a/src/boomerang/visitor/stmtexpvisitor/StmtConstFinder.h
+++ b/src/boomerang/visitor/stmtexpvisitor/StmtConstFinder.h
@@ -22,9 +22,6 @@ class ConstFinder;
 class BOOMERANG_API StmtConstFinder : public StmtExpVisitor
 {
 public:
-    StmtConstFinder()          = default;
-    virtual ~StmtConstFinder() = default;
-
-public:
     StmtConstFinder(ConstFinder *v);
+    virtual ~StmtConstFinder() = default;
 };


### PR DESCRIPTION
Explicitly mark constructors as deleted for classes with members that have deleted constructors.