### PR TITLE
Fix crash when simplifying no-choice branches

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ v0.5.0 (in development)
 - Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is a string instruction.
 - Fixed: Crash when decompiling x86 binaries that contain instructions accessing FS or GS segment registers.
 - Fixed: Crash when decompiling tail-recursive functions.
+- Fixed: Crash when decompiling branches that have the same destination for both branch edges.
 - Fixed: Crash when removing an empty jump in a delay slot on SPARC.
 - Fixed: Crash when analyzing data-flow for functions consisting of a single Basic Block.
 - Fixed: Potential crash when decompiling non-constant register expressions.

--- a/tests/unit-tests/TestUtils.cpp
+++ b/tests/unit-tests/TestUtils.cpp
@@ -77,20 +77,39 @@ char *toString(const LocationSet& locSet)
 }
 
 
+#define HANDLE_ENUM_VAL(x) case x: return QTest::toString(#x)
+
+
 char *toString(ICLASS type)
 {
     switch (type) {
-    case ICLASS::NCT:   return QTest::toString("NCT");
-    case ICLASS::SD:    return QTest::toString("SD");
-    case ICLASS::DD:    return QTest::toString("DD");
-    case ICLASS::SCD:   return QTest::toString("SCD");
-    case ICLASS::SCDAN: return QTest::toString("SCDAN");
-    case ICLASS::SCDAT: return QTest::toString("SCDAT");
-    case ICLASS::SU:    return QTest::toString("SU");
-    case ICLASS::SKIP:  return QTest::toString("SKIP");
-    case ICLASS::NOP:   return QTest::toString("NOP");
+    HANDLE_ENUM_VAL(ICLASS::NCT);
+    HANDLE_ENUM_VAL(ICLASS::SD);
+    HANDLE_ENUM_VAL(ICLASS::DD);
+    HANDLE_ENUM_VAL(ICLASS::SCD);
+    HANDLE_ENUM_VAL(ICLASS::SCDAN);
+    HANDLE_ENUM_VAL(ICLASS::SCDAT);
+    HANDLE_ENUM_VAL(ICLASS::SU);
+    HANDLE_ENUM_VAL(ICLASS::SKIP);
+    HANDLE_ENUM_VAL(ICLASS::NOP);
     }
 
     return QTest::toString("<unknown>");
 }
 
+char *toString(BBType type)
+{
+    switch (type) {
+    HANDLE_ENUM_VAL(BBType::Invalid);
+    HANDLE_ENUM_VAL(BBType::Fall);
+    HANDLE_ENUM_VAL(BBType::Oneway);
+    HANDLE_ENUM_VAL(BBType::Twoway);
+    HANDLE_ENUM_VAL(BBType::Nway);
+    HANDLE_ENUM_VAL(BBType::Ret);
+    HANDLE_ENUM_VAL(BBType::Call);
+    HANDLE_ENUM_VAL(BBType::CompJump);
+    HANDLE_ENUM_VAL(BBType::CompCall);
+    }
+
+    return QTest::toString("<unknown>");
+}

--- a/tests/unit-tests/TestUtils.h
+++ b/tests/unit-tests/TestUtils.h
@@ -13,6 +13,7 @@
 #include "boomerang/core/Project.h"
 #include "boomerang/ssl/type/Type.h"
 #include "boomerang/ssl/exp/Exp.h"
+#include "boomerang/db/BasicBlock.h"
 
 #include <QTest>
 
@@ -103,3 +104,4 @@ char *toString(const Exp& exp);
 char *toString(const SharedConstExp& exp);
 char *toString(const LocationSet& locSet);
 char *toString(ICLASS type);
+char *toString(BBType type);

--- a/tests/unit-tests/boomerang/db/BasicBlockTest.h
+++ b/tests/unit-tests/boomerang/db/BasicBlockTest.h
@@ -50,6 +50,7 @@ private slots:
     void testSetCond();
     void testGetDest();
     void testHasStatement();
+    void testSimplify();
     void testUpdateBBAddresses();
     void testIsEmpty();
     void testIsEmptyJump();


### PR DESCRIPTION
Simplifications of twoway BBs that have the same destination BB for both
branch edges left the CFG in a non-well-formed state. Additionally,
removing double branch edges between two BBs removed both edges
instead of just one.