### PR TITLE
Fix crash when decompiling BBs containing calls to helper functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ v0.5.0 (in development)
 - Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is BSF or BSR.
 - Fixed: Crash when decompiling x86 binaries that contain functions where the first instruction is a string instruction.
 - Fixed: Crash when decompiling x86 binaries that contain instructions accessing FS or GS segment registers.
+- Fixed: Crash when decompiling SPARC binaries containing calls to helper functions.
 - Fixed: Crash when decompiling tail-recursive functions.
 - Fixed: Crash when decompiling branches that have the same destination for both branch edges.
 - Fixed: Crash when removing an empty jump in a delay slot on SPARC.

--- a/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
+++ b/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.cpp
@@ -135,7 +135,7 @@ void SPARCFrontEnd::case_unhandled_stub(Address addr)
 
 
 bool SPARCFrontEnd::case_CALL(Address &address, DecodeResult &inst, DecodeResult &delayInst,
-                              std::unique_ptr<RTLList> BB_rtls, UserProc *proc,
+                              std::unique_ptr<RTLList> &BB_rtls, UserProc *proc,
                               std::list<CallStatement *> &callList, bool isPattern /* = false*/)
 {
     // Aliases for the call and delay RTLs
@@ -725,7 +725,7 @@ bool SPARCFrontEnd::processProc(UserProc *proc, Address pc)
                         // resore semantics chop off one level of return address)
                         static_cast<CallStatement *>(last)->setReturnAfterCall(true);
                         sequentialDecode = false;
-                        case_CALL(pc, inst, nop_inst, std::move(BB_rtls), proc, callList, true);
+                        case_CALL(pc, inst, nop_inst, BB_rtls, proc, callList, true);
                         break;
                     }
 
@@ -757,8 +757,8 @@ bool SPARCFrontEnd::processProc(UserProc *proc, Address pc)
                                 *rhs->getSubExp1() == *o7) {
                                 // Get the constant
                                 const int K = rhs->access<Const, 2>()->getInt();
-                                case_CALL(pc, inst, delayInst, std::move(BB_rtls), proc, callList,
-                                          true);
+                                case_CALL(pc, inst, delayInst, BB_rtls, proc, callList, true);
+
                                 // We don't generate a goto; instead, we just decode from the new
                                 // address Note: the call to case_CALL has already incremented
                                 // address by 8, so don't do again
@@ -771,8 +771,7 @@ bool SPARCFrontEnd::processProc(UserProc *proc, Address pc)
                                 // after this call
                                 static_cast<CallStatement *>(last)->setReturnAfterCall(true);
                                 sequentialDecode = false;
-                                case_CALL(pc, inst, delayInst, std::move(BB_rtls), proc, callList,
-                                          true);
+                                case_CALL(pc, inst, delayInst, BB_rtls, proc, callList, true);
                                 break;
                             }
                         }
@@ -789,8 +788,7 @@ bool SPARCFrontEnd::processProc(UserProc *proc, Address pc)
                     // we put the delay instruction before the jump or call
                     if (last->getKind() == StmtType::Call) {
                         // This is a call followed by an NCT/NOP
-                        sequentialDecode = case_CALL(pc, inst, delayInst, std::move(BB_rtls), proc,
-                                                     callList);
+                        sequentialDecode = case_CALL(pc, inst, delayInst, BB_rtls, proc, callList);
                     }
                     else {
                         // This is a non-call followed by an NCT/NOP

--- a/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.h
+++ b/src/boomerang-plugins/frontend/sparc/SPARCFrontEnd.h
@@ -148,7 +148,7 @@ private:
      * \returns true if next instruction is to be fetched sequentially from this one
      */
     bool case_CALL(Address &address, DecodeResult &inst, DecodeResult &delay_inst,
-                   std::unique_ptr<RTLList> BB_rtls, UserProc *proc,
+                   std::unique_ptr<RTLList> &BB_rtls, UserProc *proc,
                    std::list<CallStatement *> &callList, bool isPattern = false);
 
     /**


### PR DESCRIPTION
Crash was caused by throwing away the instruction semantics of the current BB when encountering a call to a helper function. If the call was in the entry BB, this would cause the entry BB to not be set.