### PR TITLE
Changed QVariantMap to QMultiMap

### DIFF
--- a/src/boomerang/db/binary/BinarySection.cpp
+++ b/src/boomerang/db/binary/BinarySection.cpp
@@ -19,7 +19,7 @@
 
 struct VariantHolder
 {
-    mutable QVariantMap val;
+    mutable QMultiMap<QString, QVariant> val;
     QVariantMap &get() const { return val; }
     VariantHolder &operator+=(const VariantHolder &other)
     {
@@ -80,18 +80,18 @@ public:
 
     QVariantMap getAttributesForRange(Address from, Address to)
     {
-        QVariantMap res;
+        QMultiMap<QString, QVariant> res;
         auto v = m_attributeMap.equalRange(from, to);
 
         if (v.first == m_attributeMap.end()) {
-            return res;
+            return std::move(res);
         }
 
         for (auto iter = v.first; iter != v.second; ++iter) {
             res.unite(iter->second.get());
         }
 
-        return res;
+        return std::move(res);
     }
 
 public:


### PR DESCRIPTION
Fix #269 : QMap::unite deprecated and removed

This is a quick fix for the deprecated method in Qt. It compiles with Qt 5.15.1 (tested on OSX).
Seasoned C++ developers should take a look at it before merging. It is good enough if you need a compiled binary right now, but there might be better ways to deal with the issue.